### PR TITLE
tweak permission on github workflows

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -6,6 +6,10 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,10 +9,12 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
     permissions:
-      contents: write  # To push a branch 
-      pages: write  # To push to a GitHub Pages site
-      id-token: write # To update the deployment status
+      contents: write
+      pages: write
+      id-token: write
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/scad.yml
+++ b/.github/workflows/scad.yml
@@ -6,6 +6,10 @@ on: [push, pull_request]
 jobs:
   render:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
this is not a problem i think, but by accident, maybe because of the repo settings with the github pages action. but on a "clean" new repo, these permissions are needed.